### PR TITLE
feat!: switch RON maps from attribute sets to key-value lists

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -47,9 +47,12 @@
             };
             map = {
               __type = "map";
-              value = {
-                key = "value";
-              };
+              value = [
+                {
+                  key = "key";
+                  value = "value";
+                }
+              ];
             };
             tuple = {
               __type = "tuple";

--- a/modules/apps/by-name/cosmic-term/default.nix
+++ b/modules/apps/by-name/cosmic-term/default.nix
@@ -458,41 +458,29 @@ lib.cosmic.applications.mkCosmicApplication {
         };
         profiles = {
           __type = "map";
-          value = builtins.listToAttrs (
-            lib.imap0 (index: profile: {
-              name = toString index;
-              value = builtins.removeAttrs profile [ "is_default" ];
-            }) cfg.profiles
-          );
+          value = lib.imap0 (index: profile: {
+            key = index;
+            value = builtins.removeAttrs profile [ "is_default" ];
+          }) cfg.profiles;
         };
       })
 
-      (lib.optionalAttrs (cfg.colorSchemes != null) (
-        let
-          colorSchemes = builtins.filter (colorscheme: colorscheme.mode == "dark") cfg.colorSchemes;
-          colorSchemesLight = builtins.filter (colorscheme: colorscheme.mode == "light") cfg.colorSchemes;
-        in
-        {
-          color_schemes_dark = {
-            __type = "map";
-            value = builtins.listToAttrs (
-              lib.imap0 (index: colorscheme: {
-                name = toString index;
-                value = builtins.removeAttrs colorscheme [ "mode" ];
-              }) colorSchemes
-            );
-          };
-          color_schemes_light = {
-            __type = "map";
-            value = builtins.listToAttrs (
-              lib.imap0 (index: colorscheme: {
-                name = toString index;
-                value = builtins.removeAttrs colorscheme [ "mode" ];
-              }) colorSchemesLight
-            );
-          };
-        }
-      ))
+      (lib.optionalAttrs (cfg.colorSchemes != null) {
+        color_schemes_dark = {
+          __type = "map";
+          value = lib.imap0 (index: colorscheme: {
+            key = index;
+            value = builtins.removeAttrs colorscheme [ "mode" ];
+          }) (builtins.filter (colorscheme: colorscheme.mode == "dark") cfg.colorSchemes);
+        };
+        color_schemes_light = {
+          __type = "map";
+          value = lib.imap0 (index: colorscheme: {
+            key = index;
+            value = builtins.removeAttrs colorscheme [ "mode" ];
+          }) (builtins.filter (colorscheme: colorscheme.mode == "light") cfg.colorSchemes);
+        };
+      })
     ];
   };
 }


### PR DESCRIPTION
- Update lib/generators.nix to handle maps as lists in toRON.
- Modify lib/types.nix and lib/options.nix to validate, merge, and produce map entries as lists.
- Update cosmic-term module to store color schemes and profiles using list-based maps for RON output.

BREAKING CHANGE: The RON map structure now uses an array of key/value objects instead of attribute sets.