### PR TITLE
feat: add support for COSMIC applets

### DIFF
--- a/lib/applets.nix
+++ b/lib/applets.nix
@@ -1,0 +1,90 @@
+{ lib, ... }:
+{
+  mkCosmicApplet =
+    {
+      configurationVersion,
+      extraConfig ? _cfg: { },
+      extraOptions ? { },
+      hasSettings ? true,
+      identifier,
+      imports ? [ ],
+      isBuiltin ? true,
+      maintainers,
+      name,
+      originalName ? name,
+      package ? if isBuiltin then null else package,
+      settingsDescription ? "Configuration entries for ${originalName} applet.",
+      settingsOptions ? { },
+      settingsExample ? null,
+    }@args:
+    let
+      module =
+        { config, pkgs, ... }:
+        let
+          cfg = config.wayland.desktopManager.cosmic.applets.${name};
+        in
+        {
+          options.wayland.desktopManager.cosmic.applets.${name} =
+            lib.optionalAttrs (!isBuiltin) {
+              enable = lib.mkEnableOption "${originalName} applet";
+              package = lib.mkPackageOption pkgs package {
+                extraDescription = "Set to `null` if you don't want to install the package.";
+                nullable = true;
+              };
+            }
+            // lib.optionalAttrs hasSettings {
+              settings = lib.cosmic.options.mkSettingsOption {
+                description = settingsDescription;
+                example = settingsExample;
+                options = settingsOptions;
+              };
+            }
+            // extraOptions;
+
+          config =
+            let
+              anySettingsSet =
+                (lib.pipe cfg.settings [
+                  builtins.attrValues
+                  (builtins.filter (x: x != null))
+                  builtins.length
+                ]) > 0;
+              enabled = if isBuiltin then anySettingsSet else cfg.enable;
+            in
+            lib.mkIf enabled (
+              lib.mkMerge [
+                {
+                  assertions = [
+                    {
+                      assertion = enabled -> config.wayland.desktopManager.cosmic.enable;
+                      message = "COSMIC Desktop declarative configuration must be enabled to use ${originalName} applet module.";
+                    }
+                  ];
+                }
+
+                (lib.optionalAttrs (!isBuiltin) {
+                  home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
+                })
+
+                (lib.optionalAttrs hasSettings {
+                  wayland.desktopManager.cosmic = {
+                    configFile.${identifier} = {
+                      entries = cfg.settings;
+                      version = configurationVersion;
+                    };
+                  };
+                })
+
+                (lib.optionalAttrs (args ? extraConfig) (
+                  lib.cosmic.modules.applyExtraConfig { inherit cfg extraConfig; }
+                ))
+              ]
+            );
+
+          meta.maintainers = maintainers;
+        };
+    in
+    {
+      imports = imports ++ [ module ];
+    };
+}

--- a/lib/applications.nix
+++ b/lib/applications.nix
@@ -55,7 +55,7 @@
 
               (lib.optionalAttrs hasSettings {
                 wayland.desktopManager.cosmic = {
-                  configFile."${identifier}" = {
+                  configFile.${identifier} = {
                     entries = cfg.settings;
                     version = configurationVersion;
                   };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,6 @@
 { lib, ... }:
 {
+  applets = import ./applets.nix { inherit lib; };
   applications = import ./applications.nix { inherit lib; };
   generators = import ./generators.nix { inherit lib; };
   modules = import ./modules.nix { inherit lib; };

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -61,11 +61,20 @@
                 1
               ];
             };
-            named_struct = {
+            namedStruct = {
               __name = "NamedStruct";
               value = {
                 key = "value";
               };
+            };
+            enum = {
+              __type = "enum";
+              variant = "ActiveWorkspace";
+            };
+            tupleEnum = {
+              __type = "enum";
+              variant = "TupleEnum";
+              value = [ "foobar" ];
             };
           }
         else

--- a/modules/applets/by-name/app-list/default.nix
+++ b/modules/applets/by-name/app-list/default.nix
@@ -1,0 +1,73 @@
+{ lib, ... }:
+let
+  inherit (lib.cosmic.options) mkNullOrOption;
+in
+lib.cosmic.applets.mkCosmicApplet {
+  name = "app-list";
+  originalName = "App Tray";
+  identifier = "com.system76.CosmicAppList";
+  configurationVersion = 1;
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  settingsOptions = {
+    enable_drag_source = mkNullOrOption {
+      type = lib.types.bool;
+      example = true;
+      description = ''
+        Whether to enable dragging applications from the application list.
+      '';
+    };
+
+    favorites = mkNullOrOption {
+      type = with lib.types; listOf str;
+      example = [
+        "firefox"
+        "com.system76.CosmicFiles"
+        "com.system76.CosmicEdit"
+        "com.system76.CosmicTerm"
+        "com.system76.CosmicSettings"
+      ];
+      description = ''
+        A list of applications to always be shown in the application list.
+      '';
+    };
+
+    filter_top_levels = mkNullOrOption {
+      type =
+        with lib.types;
+        ronOptionalOf (ronEnum [
+          "ActiveWorkspace"
+          "ConfiguredOutput"
+        ]);
+      example = {
+        __type = "optional";
+        value = {
+          __type = "enum";
+          variant = "ActiveWorkspace";
+        };
+      };
+      description = ''
+        The top level filter to use for the application list.
+      '';
+    };
+  };
+
+  settingsExample = {
+    enable_drag_source = true;
+    favorites = [
+      "firefox"
+      "com.system76.CosmicFiles"
+      "com.system76.CosmicEdit"
+      "com.system76.CosmicTerm"
+      "com.system76.CosmicSettings"
+    ];
+    filter_top_levels = {
+      __type = "optional";
+      value = {
+        __type = "enum";
+        variant = "ActiveWorkspace";
+      };
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,7 @@
       ;
     modules =
       let
+        appletsByName = ./applets/by-name;
         appsByName = ./apps/by-name;
       in
       [
@@ -23,7 +24,11 @@
       ++ lib.foldlAttrs (
         prev: name: type:
         prev ++ lib.optional (type == "directory") (appsByName + "/${name}")
-      ) [ ] (builtins.readDir appsByName);
+      ) [ ] (builtins.readDir appsByName)
+      ++ lib.foldlAttrs (
+        prev: name: type:
+        prev ++ lib.optional (type == "directory") (appletsByName + "/${name}")
+      ) [ ] (builtins.readDir appletsByName);
   };
 
   options.wayland.desktopManager.cosmic.enable =


### PR DESCRIPTION
Introduces a new system for managing COSMIC applets declaratively:
- Add mkCosmicApplet function for creating applet modules
- Implement app-list as first applet module
- Add applets support to the module system
- Fix string interpolation in applications config
- Add enum and tuple enum examples to options

This allows users to configure COSMIC applets through home-manager, starting with the App Tray applet.