### PR TITLE
fix: make the default value of options `null`

### DIFF
--- a/modules/appearance.nix
+++ b/modules/appearance.nix
@@ -1193,191 +1193,178 @@
             };
         in
         {
-          dark = lib.mkOption {
-            type = themeSubmodule;
-            default = { };
-            example = {
-              active_hint = 3;
-            };
-            description = ''
-              The dark theme to build for COSMIC desktop and applications.
-            '';
-          };
+          dark = defaultNullOpts.mkNullable themeSubmodule { active_hint = 3; } ''
+            The dark theme to build for COSMIC desktop and applications.
+          '';
 
           default = defaultNullOpts.mkEnum [ "dark" "light" ] "dark" ''
             The default theme to use for COSMIC desktop and applications.
           '';
 
-          light = lib.mkOption {
-            type = themeSubmodule;
-            default = { };
-            example = {
-              active_hint = 3;
-            };
-            description = ''
-              The light theme to build for COSMIC desktop and applications.
-            '';
-          };
+          light = defaultNullOpts.mkNullable themeSubmodule { active_hint = 3; } ''
+            The light theme to build for COSMIC desktop and applications.
+          '';
         };
 
-      toolkit = lib.mkOption {
-        type = lib.types.submodule {
-          freeformType = with lib.types; attrsOf cosmicEntryValue;
-          options =
-            let
-              fontSubmodule = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  family = lib.mkOption {
-                    type = with lib.types; maybeRonRaw str;
-                    example = "Inter";
-                    description = ''
-                      The font family to use.
-                    '';
-                  };
+      toolkit =
+        let
+          toolkitSubmodule = lib.types.submodule {
+            freeformType = with lib.types; attrsOf cosmicEntryValue;
+            options =
+              let
+                fontSubmodule = lib.types.submodule {
+                  freeformType = with lib.types; attrsOf cosmicEntryValue;
+                  options = {
+                    family = lib.mkOption {
+                      type = with lib.types; maybeRonRaw str;
+                      example = "Inter";
+                      description = ''
+                        The font family to use.
+                      '';
+                    };
 
-                  stretch = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (ronEnum [
-                        "UltraCondensed"
-                        "ExtraCondensed"
-                        "Condensed"
-                        "SemiCondensed"
-                        "Normal"
-                        "SemiExpanded"
-                        "Expanded"
-                        "ExtraExpanded"
-                        "UltraExpanded"
-                      ]);
-                    example = mkRonExpression 0 {
-                      __type = "enum";
-                      variant = "Normal";
-                    } null;
-                    description = ''
-                      The font stretch to use.
-                    '';
-                  };
+                    stretch = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (ronEnum [
+                          "UltraCondensed"
+                          "ExtraCondensed"
+                          "Condensed"
+                          "SemiCondensed"
+                          "Normal"
+                          "SemiExpanded"
+                          "Expanded"
+                          "ExtraExpanded"
+                          "UltraExpanded"
+                        ]);
+                      example = mkRonExpression 0 {
+                        __type = "enum";
+                        variant = "Normal";
+                      } null;
+                      description = ''
+                        The font stretch to use.
+                      '';
+                    };
 
-                  style = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (ronEnum [
-                        "Normal"
-                        "Italic"
-                        "Oblique"
-                      ]);
-                    example = mkRonExpression 0 {
-                      __type = "enum";
-                      variant = "Normal";
-                    } null;
-                    description = ''
-                      The font style to use.
-                    '';
-                  };
+                    style = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (ronEnum [
+                          "Normal"
+                          "Italic"
+                          "Oblique"
+                        ]);
+                      example = mkRonExpression 0 {
+                        __type = "enum";
+                        variant = "Normal";
+                      } null;
+                      description = ''
+                        The font style to use.
+                      '';
+                    };
 
-                  weight = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (ronEnum [
-                        "Thin"
-                        "ExtraLight"
-                        "Light"
-                        "Normal"
-                        "Medium"
-                        "Semibold"
-                        "Bold"
-                        "ExtraBold"
-                        "Black"
-                      ]);
-                    example = mkRonExpression 0 {
-                      __type = "enum";
-                      variant = "Normal";
-                    } null;
-                    description = ''
-                      The font weight to use.
-                    '';
+                    weight = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (ronEnum [
+                          "Thin"
+                          "ExtraLight"
+                          "Light"
+                          "Normal"
+                          "Medium"
+                          "Semibold"
+                          "Bold"
+                          "ExtraBold"
+                          "Black"
+                        ]);
+                      example = mkRonExpression 0 {
+                        __type = "enum";
+                        variant = "Normal";
+                      } null;
+                      description = ''
+                        The font weight to use.
+                      '';
+                    };
                   };
                 };
+              in
+              {
+                apply_theme_global = defaultNullOpts.mkBool false ''
+                  Whether to apply the theme to other toolkits (GTK, etc.).
+                '';
+
+                header_size = defaultNullOpts.mkRonEnum [ "Compact" "Spacious" "Standard" ] "Standard" ''
+                  The header size for COSMIC desktop and applications.
+                '';
+
+                icon_theme = defaultNullOpts.mkStr "Cosmic" ''
+                  The icon theme to use for COSMIC desktop and applications.
+                '';
+
+                interface_density = defaultNullOpts.mkRonEnum [ "Compact" "Spacious" "Standard" ] "Standard" ''
+                  The interface density to use for COSMIC desktop and applications.
+                '';
+
+                interface_font =
+                  defaultNullOpts.mkNullable fontSubmodule
+                    {
+                      family = "Inter";
+                      stretch = {
+                        __type = "enum";
+                        variant = "Normal";
+                      };
+                      style = {
+                        __type = "enum";
+                        variant = "Normal";
+                      };
+                      weight = {
+                        __type = "enum";
+                        variant = "Normal";
+                      };
+                    }
+                    ''
+                      The interface font to use for COSMIC desktop and applications.
+                    '';
+
+                monospace_font =
+                  defaultNullOpts.mkNullable fontSubmodule
+                    {
+                      family = "JetBrains Mono";
+                      stretch = {
+                        __type = "enum";
+                        variant = "Normal";
+                      };
+                      style = {
+                        __type = "enum";
+                        variant = "Normal";
+                      };
+                      weight = {
+                        __type = "enum";
+                        variant = "Normal";
+                      };
+                    }
+                    ''
+                      The monospace font to use for COSMIC desktop and applications.
+                    '';
+
+                show_maximize = defaultNullOpts.mkBool true ''
+                  Whether to show the maximize button in the window title bar.
+                '';
+
+                show_minimize = defaultNullOpts.mkBool true ''
+                  Whether to show the minimize button in the window title bar.
+                '';
               };
-            in
-            {
-              apply_theme_global = defaultNullOpts.mkBool false ''
-                Whether to apply the theme to other toolkits (GTK, etc.).
-              '';
-
-              header_size = defaultNullOpts.mkRonEnum [ "Compact" "Spacious" "Standard" ] "Standard" ''
-                The header size for COSMIC desktop and applications.
-              '';
-
-              icon_theme = defaultNullOpts.mkStr "Cosmic" ''
-                The icon theme to use for COSMIC desktop and applications.
-              '';
-
-              interface_density = defaultNullOpts.mkRonEnum [ "Compact" "Spacious" "Standard" ] "Standard" ''
-                The interface density to use for COSMIC desktop and applications.
-              '';
-
-              interface_font =
-                defaultNullOpts.mkNullable fontSubmodule
-                  {
-                    family = "Inter";
-                    stretch = {
-                      __type = "enum";
-                      variant = "Normal";
-                    };
-                    style = {
-                      __type = "enum";
-                      variant = "Normal";
-                    };
-                    weight = {
-                      __type = "enum";
-                      variant = "Normal";
-                    };
-                  }
-                  ''
-                    The interface font to use for COSMIC desktop and applications.
-                  '';
-
-              monospace_font =
-                defaultNullOpts.mkNullable fontSubmodule
-                  {
-                    family = "JetBrains Mono";
-                    stretch = {
-                      __type = "enum";
-                      variant = "Normal";
-                    };
-                    style = {
-                      __type = "enum";
-                      variant = "Normal";
-                    };
-                    weight = {
-                      __type = "enum";
-                      variant = "Normal";
-                    };
-                  }
-                  ''
-                    The monospace font to use for COSMIC desktop and applications.
-                  '';
-
-              show_maximize = defaultNullOpts.mkBool true ''
-                Whether to show the maximize button in the window title bar.
-              '';
-
-              show_minimize = defaultNullOpts.mkBool true ''
-                Whether to show the minimize button in the window title bar.
-              '';
-            };
-        };
-        default = { };
-        example = {
-          apply_theme_global = false;
-          icon_theme = "Cosmic";
-        };
-        description = ''
-          The toolkit configuration for COSMIC desktop and applications.
-        '';
-      };
+          };
+        in
+        defaultNullOpts.mkNullable toolkitSubmodule
+          {
+            apply_theme_global = false;
+            icon_theme = "Cosmic";
+          }
+          ''
+            The toolkit configuration for COSMIC desktop and applications.
+          '';
     };
 
   config =
@@ -1393,22 +1380,22 @@
 
           needsBuild =
             builtins.any (panel: panel.background != null && panel.background.variant == "Color") cfg.panels
-            || cfg.appearance.theme.dark != { }
-            || cfg.appearance.theme.light != { };
+            || cfg.appearance.theme.dark != null
+            || cfg.appearance.theme.light != null;
         in
         lib.mkIf needsBuild (
           lib.hm.dag.entryAfter [ "configureCosmic" ] "run ${lib.getExe cosmic-manager-cli} build-theme"
         );
 
       wayland.desktopManager.cosmic.configFile = lib.mkMerge [
-        (lib.mkIf (cfg.appearance.theme.dark != { }) {
+        (lib.mkIf (cfg.appearance.theme.dark != null) {
           "com.system76.CosmicTheme.Dark.Builder" = {
             entries = cfg.appearance.theme.dark;
             inherit version;
           };
         })
 
-        (lib.mkIf (cfg.appearance.theme.light != { }) {
+        (lib.mkIf (cfg.appearance.theme.light != null) {
           "com.system76.CosmicTheme.Light.Builder" = {
             entries = cfg.appearance.theme.light;
             inherit version;
@@ -1422,7 +1409,7 @@
           };
         })
 
-        (lib.mkIf (cfg.appearance.toolkit != { }) {
+        (lib.mkIf (cfg.appearance.toolkit != null) {
           "com.system76.CosmicTk" = {
             entries = cfg.appearance.toolkit;
             inherit version;

--- a/modules/applets/by-name/app-list/default.nix
+++ b/modules/applets/by-name/app-list/default.nix
@@ -1,7 +1,4 @@
 { lib, ... }:
-let
-  inherit (lib.cosmic) defaultNullOpts;
-in
 lib.cosmic.applets.mkCosmicApplet {
   name = "app-list";
   originalName = "App Tray";
@@ -10,41 +7,45 @@ lib.cosmic.applets.mkCosmicApplet {
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 
-  settingsOptions = {
-    enable_drag_source = defaultNullOpts.mkBool true ''
-      Whether to enable dragging applications from the application list.
-    '';
+  settingsOptions =
+    let
+      inherit (lib.cosmic) defaultNullOpts;
+    in
+    {
+      enable_drag_source = defaultNullOpts.mkBool true ''
+        Whether to enable dragging applications from the application list.
+      '';
 
-    favorites =
-      defaultNullOpts.mkListOf lib.types.str
-        [
-          "firefox"
-          "com.system76.CosmicFiles"
-          "com.system76.CosmicEdit"
-          "com.system76.CosmicTerm"
-          "com.system76.CosmicSettings"
-        ]
-        ''
-          A list of applications to always be shown in the application list.
-        '';
+      favorites =
+        defaultNullOpts.mkListOf lib.types.str
+          [
+            "firefox"
+            "com.system76.CosmicFiles"
+            "com.system76.CosmicEdit"
+            "com.system76.CosmicTerm"
+            "com.system76.CosmicSettings"
+          ]
+          ''
+            A list of applications to always be shown in the application list.
+          '';
 
-    filter_top_levels =
-      defaultNullOpts.mkRonOptionalOf
-        (lib.types.ronEnum [
-          "ActiveWorkspace"
-          "ConfiguredOutput"
-        ])
-        {
-          __type = "optional";
-          value = {
-            __type = "enum";
-            variant = "ActiveWorkspace";
-          };
-        }
-        ''
-          The top level filter to use for the application list.
-        '';
-  };
+      filter_top_levels =
+        defaultNullOpts.mkRonOptionalOf
+          (lib.types.ronEnum [
+            "ActiveWorkspace"
+            "ConfiguredOutput"
+          ])
+          {
+            __type = "optional";
+            value = {
+              __type = "enum";
+              variant = "ActiveWorkspace";
+            };
+          }
+          ''
+            The top level filter to use for the application list.
+          '';
+    };
 
   settingsExample = {
     enable_drag_source = true;

--- a/modules/applets/by-name/audio/default.nix
+++ b/modules/applets/by-name/audio/default.nix
@@ -1,7 +1,4 @@
 { lib, ... }:
-let
-  inherit (lib.cosmic) defaultNullOpts;
-in
 lib.cosmic.applets.mkCosmicApplet {
   name = "audio";
   originalName = "Sound";
@@ -10,11 +7,15 @@ lib.cosmic.applets.mkCosmicApplet {
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 
-  settingsOptions = {
-    show_media_controls_in_top_panel = defaultNullOpts.mkBool true ''
-      Whether to show media controls in the top panel.
-    '';
-  };
+  settingsOptions =
+    let
+      inherit (lib.cosmic) defaultNullOpts;
+    in
+    {
+      show_media_controls_in_top_panel = defaultNullOpts.mkBool true ''
+        Whether to show media controls in the top panel.
+      '';
+    };
 
   settingsExample = {
     show_media_controls_in_top_panel = true;

--- a/modules/applets/by-name/time/default.nix
+++ b/modules/applets/by-name/time/default.nix
@@ -1,7 +1,4 @@
 { lib, ... }:
-let
-  inherit (lib.cosmic) defaultNullOpts;
-in
 lib.cosmic.applets.mkCosmicApplet {
   name = "time";
   originalName = "Date, Time & Calendar";
@@ -10,29 +7,33 @@ lib.cosmic.applets.mkCosmicApplet {
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 
-  settingsOptions = {
-    first_day_of_week = defaultNullOpts.mkU8 6 ''
-      Which day of the week should be considered the first day.
+  settingsOptions =
+    let
+      inherit (lib.cosmic) defaultNullOpts;
+    in
+    {
+      first_day_of_week = defaultNullOpts.mkU8 6 ''
+        Which day of the week should be considered the first day.
 
-      `0` for Monday, `1` for Tuesday, and so on.
-    '';
+        `0` for Monday, `1` for Tuesday, and so on.
+      '';
 
-    military_time = defaultNullOpts.mkBool false ''
-      Whether to use the 24-hour format for the clock.
-    '';
+      military_time = defaultNullOpts.mkBool false ''
+        Whether to use the 24-hour format for the clock.
+      '';
 
-    show_date_in_top_panel = defaultNullOpts.mkBool true ''
-      Whether to show the current date in the top panel.
-    '';
+      show_date_in_top_panel = defaultNullOpts.mkBool true ''
+        Whether to show the current date in the top panel.
+      '';
 
-    show_seconds = defaultNullOpts.mkBool false ''
-      Whether to show the seconds in the clock.
-    '';
+      show_seconds = defaultNullOpts.mkBool false ''
+        Whether to show the seconds in the clock.
+      '';
 
-    show_weekday = defaultNullOpts.mkBool true ''
-      Whether to show the current weekday in the clock.
-    '';
-  };
+      show_weekday = defaultNullOpts.mkBool true ''
+        Whether to show the current weekday in the clock.
+      '';
+    };
 
   settingsExample = {
     first_day_of_week = 6;

--- a/modules/apps/by-name/cosmic-files/default.nix
+++ b/modules/apps/by-name/cosmic-files/default.nix
@@ -1,7 +1,4 @@
 { lib, ... }:
-let
-  inherit (lib.cosmic) defaultNullOpts mkRonExpression;
-in
 lib.cosmic.applications.mkCosmicApplication {
   name = "cosmic-files";
   originalName = "COSMIC Files";
@@ -10,201 +7,209 @@ lib.cosmic.applications.mkCosmicApplication {
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 
-  settingsOptions = {
-    app_theme =
-      defaultNullOpts.mkRonEnum [ "Dark" "Light" "System" ]
-        {
-          __type = "enum";
-          variant = "System";
-        }
-        ''
-          The theme of the application.
-        '';
+  settingsOptions =
+    let
+      inherit (lib.cosmic) defaultNullOpts;
+    in
+    {
+      app_theme =
+        defaultNullOpts.mkRonEnum [ "Dark" "Light" "System" ]
+          {
+            __type = "enum";
+            variant = "System";
+          }
+          ''
+            The theme of the application.
+          '';
 
-    desktop =
-      defaultNullOpts.mkNullable
-        (lib.types.submodule {
-          freeformType = with lib.types; attrsOf cosmicEntryValue;
-          options = {
-            show_content = lib.mkOption {
-              type = with lib.types; maybeRonRaw bool;
-              example = true;
-              description = ''
-                Whether to show the content of the Desktop folder.
-              '';
+      desktop =
+        defaultNullOpts.mkNullable
+          (lib.types.submodule {
+            freeformType = with lib.types; attrsOf cosmicEntryValue;
+            options = {
+              show_content = lib.mkOption {
+                type = with lib.types; maybeRonRaw bool;
+                example = true;
+                description = ''
+                  Whether to show the content of the Desktop folder.
+                '';
+              };
+
+              show_mounted_drives = lib.mkOption {
+                type = with lib.types; maybeRonRaw bool;
+                example = false;
+                description = ''
+                  Whether to show mounted drives on the Desktop.
+                '';
+              };
+
+              show_trash = lib.mkOption {
+                type = with lib.types; maybeRonRaw bool;
+                example = false;
+                description = ''
+                  Whether to show the Trash on the Desktop.
+                '';
+              };
             };
-
-            show_mounted_drives = lib.mkOption {
-              type = with lib.types; maybeRonRaw bool;
-              example = false;
-              description = ''
-                Whether to show mounted drives on the Desktop.
-              '';
-            };
-
-            show_trash = lib.mkOption {
-              type = with lib.types; maybeRonRaw bool;
-              example = false;
-              description = ''
-                Whether to show the Trash on the Desktop.
-              '';
-            };
-          };
-        })
-        {
-          show_content = true;
-          show_mounted_drives = false;
-          show_trash = false;
-        }
-        ''
-          The desktop icons settings.
-        '';
-
-    favorites =
-      defaultNullOpts.mkListOf
-        (
-          with lib.types;
-          either (ronEnum [
-            "Documents"
-            "Downloads"
-            "Home"
-            "Music"
-            "Pictures"
-            "Videos"
-          ]) (ronTupleEnumOf lib.types.str [ "Path" ] 1)
-        )
-        [
+          })
           {
-            __type = "enum";
-            variant = "Home";
+            show_content = true;
+            show_mounted_drives = false;
+            show_trash = false;
           }
-          {
-            __type = "enum";
-            variant = "Documents";
-          }
-          {
-            __type = "enum";
-            variant = "Downloads";
-          }
-          {
-            __type = "enum";
-            variant = "Music";
-          }
-          {
-            __type = "enum";
-            variant = "Pictures";
-          }
-          {
-            __type = "enum";
-            variant = "Videos";
-          }
-        ]
-        ''
-          The list of favorite folders.
-        '';
+          ''
+            The desktop icons settings.
+          '';
 
-    show_details = defaultNullOpts.mkBool false ''
-      Whether to show file details.
-    '';
+      favorites =
+        defaultNullOpts.mkListOf
+          (
+            with lib.types;
+            either (ronEnum [
+              "Documents"
+              "Downloads"
+              "Home"
+              "Music"
+              "Pictures"
+              "Videos"
+            ]) (ronTupleEnumOf lib.types.str [ "Path" ] 1)
+          )
+          [
+            {
+              __type = "enum";
+              variant = "Home";
+            }
+            {
+              __type = "enum";
+              variant = "Documents";
+            }
+            {
+              __type = "enum";
+              variant = "Downloads";
+            }
+            {
+              __type = "enum";
+              variant = "Music";
+            }
+            {
+              __type = "enum";
+              variant = "Pictures";
+            }
+            {
+              __type = "enum";
+              variant = "Videos";
+            }
+          ]
+          ''
+            The list of favorite folders.
+          '';
 
-    tab =
-      defaultNullOpts.mkNullable
-        (lib.types.submodule {
-          freeformType = with lib.types; attrsOf cosmicEntryValue;
-          options = {
-            folders_first = lib.mkOption {
-              type = with lib.types; maybeRonRaw bool;
-              example = true;
-              description = ''
-                Whether to show folders before files.
-              '';
-            };
+      show_details = defaultNullOpts.mkBool false ''
+        Whether to show file details.
+      '';
 
-            icon_sizes = lib.mkOption {
-              type = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  grid = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (
-                        addCheck ints.u16 (x: x > 0)
-                        // {
-                          description = "Non-zero unsigned 16-bit integer";
-                        }
-                      );
-                    example = 100;
-                    description = ''
-                      The size of the icons in the grid view.
-                    '';
-                  };
+      tab =
+        defaultNullOpts.mkNullable
+          (lib.types.submodule {
+            freeformType = with lib.types; attrsOf cosmicEntryValue;
+            options = {
+              folders_first = lib.mkOption {
+                type = with lib.types; maybeRonRaw bool;
+                example = true;
+                description = ''
+                  Whether to show folders before files.
+                '';
+              };
 
-                  list = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (
-                        addCheck ints.u16 (x: x > 0)
-                        // {
-                          description = "Non-zero unsigned 16-bit integer";
-                        }
-                      );
-                    example = 100;
-                    description = ''
-                      The size of the icons in the list view.
-                    '';
+              icon_sizes = lib.mkOption {
+                type = lib.types.submodule {
+                  freeformType = with lib.types; attrsOf cosmicEntryValue;
+                  options = {
+                    grid = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (
+                          addCheck ints.u16 (x: x > 0)
+                          // {
+                            description = "Non-zero unsigned 16-bit integer";
+                          }
+                        );
+                      example = 100;
+                      description = ''
+                        The size of the icons in the grid view.
+                      '';
+                    };
+
+                    list = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (
+                          addCheck ints.u16 (x: x > 0)
+                          // {
+                            description = "Non-zero unsigned 16-bit integer";
+                          }
+                        );
+                      example = 100;
+                      description = ''
+                        The size of the icons in the list view.
+                      '';
+                    };
                   };
                 };
+                example = {
+                  grid = 100;
+                  list = 100;
+                };
+                description = ''
+                  The icon sizes of the grid and list views.
+                '';
               };
-              example = {
-                grid = 100;
-                list = 100;
+
+              show_hidden = lib.mkOption {
+                type = with lib.types; maybeRonRaw bool;
+                example = false;
+                description = ''
+                  Whether to show hidden files.
+                '';
               };
-              description = ''
-                The icon sizes of the grid and list views.
-              '';
-            };
 
-            show_hidden = lib.mkOption {
-              type = with lib.types; maybeRonRaw bool;
-              example = false;
-              description = ''
-                Whether to show hidden files.
-              '';
+              view = lib.mkOption {
+                type =
+                  with lib.types;
+                  maybeRonRaw (ronEnum [
+                    "Grid"
+                    "List"
+                  ]);
+                example =
+                  let
+                    inherit (lib.cosmic) mkRonExpression;
+                  in
+                  mkRonExpression 0 {
+                    __type = "enum";
+                    variant = "List";
+                  } null;
+                description = ''
+                  The default view of the tab.
+                '';
+              };
             };
-
-            view = lib.mkOption {
-              type =
-                with lib.types;
-                maybeRonRaw (ronEnum [
-                  "Grid"
-                  "List"
-                ]);
-              example = mkRonExpression 0 {
-                __type = "enum";
-                variant = "List";
-              } null;
-              description = ''
-                The default view of the tab.
-              '';
+          })
+          {
+            folders_first = true;
+            icon_sizes = {
+              grid = 100;
+              list = 100;
             };
-          };
-        })
-        {
-          folders_first = true;
-          icon_sizes = {
-            grid = 100;
-            list = 100;
-          };
-          show_hidden = false;
-          view = {
-            __type = "enum";
-            variant = "List";
-          };
-        }
-        ''
-          The tab settings.
-        '';
-  };
+            show_hidden = false;
+            view = {
+              __type = "enum";
+              variant = "List";
+            };
+          }
+          ''
+            The tab settings.
+          '';
+    };
 
   settingsExample = {
     app_theme = {

--- a/modules/apps/by-name/cosmic-term/default.nix
+++ b/modules/apps/by-name/cosmic-term/default.nix
@@ -170,9 +170,8 @@ lib.cosmic.applications.mkCosmicApplication {
           };
         };
       in
-      lib.mkOption {
-        type = with lib.types; listOf profileSubmodule;
-        default = [ ];
+      defaultNullOpts.mkNullable' {
+        type = lib.types.listOf profileSubmodule;
         example = [
           {
             command = "bash";
@@ -344,9 +343,8 @@ lib.cosmic.applications.mkCosmicApplication {
           };
         };
       in
-      lib.mkOption {
+      defaultNullOpts.mkNullable' {
         type = lib.types.listOf colorSchemeSubmodule;
-        default = [ ];
         example = [
           {
             mode = "dark";
@@ -395,7 +393,7 @@ lib.cosmic.applications.mkCosmicApplication {
 
   extraConfig = cfg: {
     wayland.desktopManager.cosmic.configFile."com.system76.CosmicTerm".entries = lib.mkMerge [
-      (lib.optionalAttrs (cfg.profiles != [ ]) {
+      (lib.mkIf (cfg.profiles != null) {
         default_profile = {
           __type = "optional";
           value = lib.lists.findFirstIndex (profile: profile.is_default) null cfg.profiles;
@@ -409,7 +407,7 @@ lib.cosmic.applications.mkCosmicApplication {
         };
       })
 
-      (lib.optionalAttrs (cfg.colorSchemes != [ ]) {
+      (lib.mkIf (cfg.colorSchemes != null) {
         color_schemes_dark = {
           __type = "map";
           value = lib.imap0 (index: colorscheme: {

--- a/modules/compositor.nix
+++ b/modules/compositor.nix
@@ -2,585 +2,589 @@
 {
   options.wayland.desktopManager.cosmic.compositor =
     let
-      inherit (lib.cosmic) defaultNullOpts mkRonExpression;
+      inherit (lib.cosmic) defaultNullOpts;
 
-      inputSubmodule = lib.types.submodule {
-        freeformType = with lib.types; attrsOf cosmicEntryValue;
-        options = {
-          acceleration =
-            let
-              accelerationSubmodule = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  profile = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (
-                        ronOptionalOf (
-                          maybeRonRaw (ronEnum [
-                            "Adaptive"
-                            "Flat"
-                          ])
-                        )
-                      );
-                    example = mkRonExpression 0 {
-                      __type = "optional";
-                      value = {
-                        __type = "enum";
-                        variant = "Flat";
+      compositorSubmodule =
+        let
+          inherit (lib.cosmic) mkRonExpression;
+
+          inputSubmodule = lib.types.submodule {
+            freeformType = with lib.types; attrsOf cosmicEntryValue;
+            options = {
+              acceleration =
+                let
+                  accelerationSubmodule = lib.types.submodule {
+                    freeformType = with lib.types; attrsOf cosmicEntryValue;
+                    options = {
+                      profile = lib.mkOption {
+                        type =
+                          with lib.types;
+                          maybeRonRaw (
+                            ronOptionalOf (
+                              maybeRonRaw (ronEnum [
+                                "Adaptive"
+                                "Flat"
+                              ])
+                            )
+                          );
+                        example = mkRonExpression 0 {
+                          __type = "optional";
+                          value = {
+                            __type = "enum";
+                            variant = "Flat";
+                          };
+                        } null;
                       };
-                    } null;
-                  };
 
-                  speed = lib.mkOption {
-                    type = with lib.types; maybeRonRaw float;
-                    example = 0.0;
-                    description = ''
-                      The speed of the input device.
-                    '';
+                      speed = lib.mkOption {
+                        type = with lib.types; maybeRonRaw float;
+                        example = 0.0;
+                        description = ''
+                          The speed of the input device.
+                        '';
+                      };
+                    };
                   };
-                };
-              };
-            in
-            defaultNullOpts.mkNullable (lib.types.ronOptionalOf accelerationSubmodule)
-              {
-                __type = "optional";
-                value = {
-                  profile = {
+                in
+                defaultNullOpts.mkNullable (lib.types.ronOptionalOf accelerationSubmodule)
+                  {
+                    __type = "optional";
+                    value = {
+                      profile = {
+                        __type = "optional";
+                        value = {
+                          __type = "enum";
+                          variant = "Flat";
+                        };
+                      };
+                      speed = 0.0;
+                    };
+                  }
+                  ''
+                    The acceleration configuration for the input device.
+                  '';
+
+              calibration =
+                defaultNullOpts.mkRonOptionalOf (with lib.types; ronTupleOf float 6)
+                  {
+                    __type = "optional";
+                    value = {
+                      __type = "tuple";
+                      value = [
+                        1.0
+                        0.0
+                        0.0
+                        0.0
+                        1.0
+                        0.0
+                      ];
+                    };
+                  }
+                  ''
+                    The calibration matrix for the input device.
+                  '';
+
+              click_method =
+                defaultNullOpts.mkRonOptionalOf
+                  (lib.types.ronEnum [
+                    "ButtonAreas"
+                    "Clickfinger"
+                  ])
+                  {
                     __type = "optional";
                     value = {
                       __type = "enum";
-                      variant = "Flat";
+                      variant = "ButtonAreas";
+                    };
+                  }
+                  ''
+                    The click method for the input device.
+                  '';
+
+              disable_while_typing =
+                defaultNullOpts.mkRonOptionalOf lib.types.bool
+                  {
+                    __type = "optional";
+                    value = true;
+                  }
+                  ''
+                    Whether to disable the input device while typing.
+                  '';
+
+              left_handed =
+                defaultNullOpts.mkRonOptionalOf lib.types.bool
+                  {
+                    __type = "optional";
+                    value = false;
+                  }
+                  ''
+                    Whether the input device is left-handed.
+                  '';
+
+              map_to_output =
+                defaultNullOpts.mkRonOptionalOf lib.types.str
+                  {
+                    __type = "optional";
+                    value = "HDMI-A-1";
+                  }
+                  ''
+                    The output to map the input device to.
+                  '';
+
+              middle_button_emulation =
+                defaultNullOpts.mkRonOptionalOf lib.types.bool
+                  {
+                    __type = "optional";
+                    value = false;
+                  }
+                  ''
+                    Whether to emulate the middle button.
+                  '';
+
+              rotation_angle =
+                defaultNullOpts.mkRonOptionalOf lib.types.ints.u32
+                  {
+                    __type = "optional";
+                    value = 0;
+                  }
+                  ''
+                    The rotation angle of the input device.
+                  '';
+
+              scroll_config =
+                let
+                  scrollConfigSubmodule = lib.types.submodule {
+                    freeformType = with lib.types; attrsOf cosmicEntryValue;
+                    options = {
+                      method = lib.mkOption {
+                        type =
+                          with lib.types;
+                          maybeRonRaw (
+                            ronOptionalOf (
+                              maybeRonRaw (ronEnum [
+                                "Edge"
+                                "NoScroll"
+                                "OnButtonDown"
+                                "TwoFinger"
+                              ])
+                            )
+                          );
+                        example = mkRonExpression 0 {
+                          __type = "optional";
+                          value = {
+                            __type = "enum";
+                            variant = "Edge";
+                          };
+                        } null;
+                        description = ''
+                          The scroll method of the input device.
+                        '';
+                      };
+
+                      natural_scroll = lib.mkOption {
+                        type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw bool));
+                        example = true;
+                        description = ''
+                          Whether to enable natural scrolling.
+                        '';
+                      };
+
+                      scroll_button = lib.mkOption {
+                        type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw ints.u32));
+                        example = 2;
+                        description = ''
+                          The scroll button of the input device.
+                        '';
+                      };
+
+                      scroll_factor = lib.mkOption {
+                        type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw float));
+                        example = 1.0;
+                        description = ''
+                          The scroll factor of the input device.
+                        '';
+                      };
                     };
                   };
-                  speed = 0.0;
-                };
-              }
-              ''
-                The acceleration configuration for the input device.
-              '';
-
-          calibration =
-            defaultNullOpts.mkRonOptionalOf (with lib.types; ronTupleOf float 6)
-              {
-                __type = "optional";
-                value = {
-                  __type = "tuple";
-                  value = [
-                    1.0
-                    0.0
-                    0.0
-                    0.0
-                    1.0
-                    0.0
-                  ];
-                };
-              }
-              ''
-                The calibration matrix for the input device.
-              '';
-
-          click_method =
-            defaultNullOpts.mkRonOptionalOf
-              (lib.types.ronEnum [
-                "ButtonAreas"
-                "Clickfinger"
-              ])
-              {
-                __type = "optional";
-                value = {
-                  __type = "enum";
-                  variant = "ButtonAreas";
-                };
-              }
-              ''
-                The click method for the input device.
-              '';
-
-          disable_while_typing =
-            defaultNullOpts.mkRonOptionalOf lib.types.bool
-              {
-                __type = "optional";
-                value = true;
-              }
-              ''
-                Whether to disable the input device while typing.
-              '';
-
-          left_handed =
-            defaultNullOpts.mkRonOptionalOf lib.types.bool
-              {
-                __type = "optional";
-                value = false;
-              }
-              ''
-                Whether the input device is left-handed.
-              '';
-
-          map_to_output =
-            defaultNullOpts.mkRonOptionalOf lib.types.str
-              {
-                __type = "optional";
-                value = "HDMI-A-1";
-              }
-              ''
-                The output to map the input device to.
-              '';
-
-          middle_button_emulation =
-            defaultNullOpts.mkRonOptionalOf lib.types.bool
-              {
-                __type = "optional";
-                value = false;
-              }
-              ''
-                Whether to emulate the middle button.
-              '';
-
-          rotation_angle =
-            defaultNullOpts.mkRonOptionalOf lib.types.ints.u32
-              {
-                __type = "optional";
-                value = 0;
-              }
-              ''
-                The rotation angle of the input device.
-              '';
-
-          scroll_config =
-            let
-              scrollConfigSubmodule = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  method = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (
-                        ronOptionalOf (
-                          maybeRonRaw (ronEnum [
-                            "Edge"
-                            "NoScroll"
-                            "OnButtonDown"
-                            "TwoFinger"
-                          ])
-                        )
-                      );
-                    example = mkRonExpression 0 {
+                in
+                defaultNullOpts.mkNullable (lib.types.ronOptionalOf scrollConfigSubmodule)
+                  {
+                    method = {
                       __type = "optional";
                       value = {
                         __type = "enum";
                         variant = "Edge";
                       };
-                    } null;
-                    description = ''
-                      The scroll method of the input device.
-                    '';
-                  };
+                    };
+                    natural_scroll = {
+                      __type = "optional";
+                      value = true;
+                    };
+                    scroll_button = {
+                      __type = "optional";
+                      value = 2;
+                    };
+                    scroll_factor = {
+                      __type = "optional";
+                      value = 1.0;
+                    };
+                  }
+                  ''
+                    The scroll configuration for the input device.
+                  '';
 
-                  natural_scroll = lib.mkOption {
-                    type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw bool));
-                    example = true;
-                    description = ''
-                      Whether to enable natural scrolling.
-                    '';
-                  };
-
-                  scroll_button = lib.mkOption {
-                    type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw ints.u32));
-                    example = 2;
-                    description = ''
-                      The scroll button of the input device.
-                    '';
-                  };
-
-                  scroll_factor = lib.mkOption {
-                    type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw float));
-                    example = 1.0;
-                    description = ''
-                      The scroll factor of the input device.
-                    '';
-                  };
-                };
-              };
-            in
-            defaultNullOpts.mkNullable (lib.types.ronOptionalOf scrollConfigSubmodule)
-              {
-                method = {
-                  __type = "optional";
-                  value = {
+              state =
+                defaultNullOpts.mkRonEnum [ "Disabled" "DisabledOnExternalMouse" "Enabled" ]
+                  {
                     __type = "enum";
-                    variant = "Edge";
+                    variant = "Enabled";
+                  }
+                  ''
+                    The state of the input module.
+
+                    If set to Disabled, the input module is disabled.
+                    If set to DisabledOnExternalMouse, the input module is disabled when an external mouse is connected.
+                    If set to Enabled, the input module is enabled.
+                  '';
+
+              tap_config =
+                let
+                  tapConfigSubmodule = lib.types.submodule {
+                    freeformType = with lib.types; attrsOf cosmicEntryValue;
+                    options = {
+                      button_map = lib.mkOption {
+                        type =
+                          with lib.types;
+                          maybeRonRaw (
+                            ronOptionalOf (
+                              maybeRonRaw (ronEnum [
+                                "LeftMiddleRight"
+                                "LeftRightMiddle"
+                              ])
+                            )
+                          );
+                        example = mkRonExpression 0 {
+                          __type = "optional";
+                          value = {
+                            __type = "enum";
+                            variant = "LeftMiddleRight";
+                          };
+                        } null;
+                      };
+
+                      drag = lib.mkOption {
+                        type = with lib.types; maybeRonRaw bool;
+                        example = true;
+                        description = ''
+                          Whether to enable drag.
+                        '';
+                      };
+
+                      drag_lock = lib.mkOption {
+                        type = with lib.types; maybeRonRaw bool;
+                        example = true;
+                        description = ''
+                          Whether to enable drag lock.
+                        '';
+                      };
+
+                      enabled = lib.mkOption {
+                        type = with lib.types; maybeRonRaw bool;
+                        example = true;
+                        description = ''
+                          Whether to enable tap.
+                        '';
+                      };
+                    };
                   };
-                };
-                natural_scroll = {
-                  __type = "optional";
-                  value = true;
-                };
-                scroll_button = {
-                  __type = "optional";
-                  value = 2;
-                };
-                scroll_factor = {
-                  __type = "optional";
-                  value = 1.0;
-                };
-              }
-              ''
-                The scroll configuration for the input device.
-              '';
-
-          state =
-            defaultNullOpts.mkRonEnum [ "Disabled" "DisabledOnExternalMouse" "Enabled" ]
-              {
-                __type = "enum";
-                variant = "Enabled";
-              }
-              ''
-                The state of the input module.
-
-                If set to Disabled, the input module is disabled.
-                If set to DisabledOnExternalMouse, the input module is disabled when an external mouse is connected.
-                If set to Enabled, the input module is enabled.
-              '';
-
-          tap_config =
-            let
-              tapConfigSubmodule = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  button_map = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (
-                        ronOptionalOf (
-                          maybeRonRaw (ronEnum [
-                            "LeftMiddleRight"
-                            "LeftRightMiddle"
-                          ])
-                        )
-                      );
-                    example = mkRonExpression 0 {
+                in
+                defaultNullOpts.mkNullable (lib.types.ronOptionalOf tapConfigSubmodule)
+                  {
+                    button_map = {
                       __type = "optional";
                       value = {
                         __type = "enum";
                         variant = "LeftMiddleRight";
                       };
-                    } null;
-                  };
+                    };
+                    drag = {
+                      __type = "optional";
+                      value = true;
+                    };
+                    drag_lock = {
+                      __type = "optional";
+                      value = true;
+                    };
+                    enabled = {
+                      __type = "optional";
+                      value = true;
+                    };
+                  }
+                  ''
+                    The tap configuration for the input device.
+                  '';
+            };
+          };
+        in
+        lib.types.submodule {
+          freeformType = with lib.types; attrsOf cosmicEntryValue;
+          options = {
+            active_hint = defaultNullOpts.mkBool true ''
+              Whether to show the active window hint.
+            '';
 
-                  drag = lib.mkOption {
-                    type = with lib.types; maybeRonRaw bool;
-                    example = true;
-                    description = ''
-                      Whether to enable drag.
-                    '';
-                  };
+            autotile = defaultNullOpts.mkBool false ''
+              Whether to automatically tile windows.
+            '';
 
-                  drag_lock = lib.mkOption {
-                    type = with lib.types; maybeRonRaw bool;
-                    example = true;
-                    description = ''
-                      Whether to enable drag lock.
-                    '';
-                  };
+            autotile_behavior =
+              defaultNullOpts.mkRonEnum [ "Global" "PerWorkspace" ]
+                {
+                  __type = "enum";
+                  variant = "PerWorkspace";
+                }
+                ''
+                  Automatic tiling behavior.
 
-                  enabled = lib.mkOption {
-                    type = with lib.types; maybeRonRaw bool;
-                    example = true;
-                    description = ''
-                      Whether to enable tap.
-                    '';
+                  If set to Global, autotile applies to all windows in all workspaces.
+                  If set to PerWorkspace, autotile only applies to new windows, and new workspaces.
+                '';
+
+            cursor_follows_focus = defaultNullOpts.mkBool false ''
+              Whether the cursor should follow the focused window.
+            '';
+
+            descale_xwayland = defaultNullOpts.mkBool false ''
+              Whether to let XWayland windows be scaled by themselves.
+            '';
+
+            focus_follows_cursor = defaultNullOpts.mkBool false ''
+              Whether the focused window should follow the cursor.
+            '';
+
+            focus_follows_cursor_delay = defaultNullOpts.mkUnsignedInt 250 ''
+              The delay in milliseconds before the focused window follows the cursor.
+            '';
+
+            input_default =
+              defaultNullOpts.mkNullable inputSubmodule
+                {
+                  acceleration = {
+                    profile = {
+                      __type = "optional";
+                      value = {
+                        __type = "enum";
+                        variant = "Flat";
+                      };
+                    };
+                    speed = 0.0;
                   };
-                };
-              };
-            in
-            defaultNullOpts.mkNullable (lib.types.ronOptionalOf tapConfigSubmodule)
-              {
-                button_map = {
-                  __type = "optional";
-                  value = {
+                  state = {
                     __type = "enum";
-                    variant = "LeftMiddleRight";
+                    variant = "Enabled";
+                  };
+                }
+                ''
+                  The input configuration for mice.
+                '';
+
+            input_touchpad =
+              defaultNullOpts.mkNullable inputSubmodule
+                {
+                  acceleration = {
+                    profile = {
+                      __type = "optional";
+                      value = {
+                        __type = "enum";
+                        variant = "Flat";
+                      };
+                    };
+                    speed = 0.0;
+                  };
+                  click_method = {
+                    __type = "optional";
+                    value = {
+                      __type = "enum";
+                      variant = "Clickfinger";
+                    };
+                  };
+                  disable_while_typing = {
+                    __type = "optional";
+                    value = true;
+                  };
+                  state = {
+                    __type = "enum";
+                    variant = "Enabled";
+                  };
+                  tap_config = {
+                    button_map = {
+                      __type = "optional";
+                      value = {
+                        __type = "enum";
+                        variant = "LeftMiddleRight";
+                      };
+                    };
+                    drag = {
+                      __type = "optional";
+                      value = true;
+                    };
+                    drag_lock = {
+                      __type = "optional";
+                      value = true;
+                    };
+                    enabled = {
+                      __type = "optional";
+                      value = true;
+                    };
+                  };
+                }
+                ''
+                  The input configuration for touchpad.
+                '';
+
+            workspaces =
+              let
+                workspacesSubmodule = lib.types.submodule {
+                  freeformType = with lib.types; attrsOf cosmicEntryValue;
+                  options = {
+                    workspace_layout = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (ronEnum [
+                          "Horizontal"
+                          "Vertical"
+                        ]);
+                      example = mkRonExpression 0 {
+                        __type = "enum";
+                        variant = "Vertical";
+                      } null;
+                      description = ''
+                        The layout of the workspaces.
+
+                        If set to Horizontal, workspaces are arranged horizontally.
+                        If set to Vertical, workspaces are arranged vertically.
+                      '';
+                    };
+
+                    workspace_mode = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (ronEnum [
+                          "Global"
+                          "OutputBound"
+                        ]);
+                      example = mkRonExpression 0 {
+                        __type = "enum";
+                        variant = "OutputBound";
+                      } null;
+                      description = ''
+                        The mode of the workspaces.
+
+                        If set to Global, workspaces are shared across all outputs.
+                        If set to OutputBound, workspaces are bound to the output they are created on.
+                      '';
+                    };
                   };
                 };
-                drag = {
-                  __type = "optional";
-                  value = true;
+              in
+              defaultNullOpts.mkNullable workspacesSubmodule
+                {
+                  workspace_layout = {
+                    __type = "enum";
+                    variant = "Vertical";
+                  };
+                  workspace_mode = {
+                    __type = "enum";
+                    variant = "OutputBound";
+                  };
+                }
+                ''
+                  The workspaces configuration for the COSMIC compositor.
+                '';
+
+            xkb_config =
+              let
+                xkbConfigSubmodule = lib.types.submodule {
+                  freeformType = with lib.types; attrsOf cosmicEntryValue;
+                  options = {
+                    layout = lib.mkOption {
+                      type = with lib.types; maybeRonRaw str;
+                      example = "br";
+                      description = ''
+                        The keyboard layout.
+                      '';
+                    };
+
+                    model = lib.mkOption {
+                      type = with lib.types; maybeRonRaw str;
+                      example = "pc104";
+                      description = ''
+                        The keyboard model.
+                      '';
+                    };
+
+                    options = lib.mkOption {
+                      type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw str));
+                      example = "terminate:ctrl_alt_bksp";
+                      description = ''
+                        The keyboard options.
+                      '';
+                    };
+
+                    repeat_delay = lib.mkOption {
+                      type = with lib.types; maybeRonRaw ints.u32;
+                      example = 600;
+                      description = ''
+                        The keyboard repeat delay.
+                      '';
+                    };
+
+                    repeat_rate = lib.mkOption {
+                      type = with lib.types; maybeRonRaw ints.u32;
+                      example = 25;
+                      description = ''
+                        The keyboard repeat rate.
+                      '';
+                    };
+
+                    rules = lib.mkOption {
+                      type = with lib.types; maybeRonRaw str;
+                      description = ''
+                        The keyboard rules.
+                      '';
+                    };
+
+                    variant = lib.mkOption {
+                      type = with lib.types; maybeRonRaw str;
+                      example = "dvorak";
+                      description = ''
+                        The keyboard variant.
+                      '';
+                    };
+                  };
                 };
-                drag_lock = {
-                  __type = "optional";
-                  value = true;
-                };
-                enabled = {
-                  __type = "optional";
-                  value = true;
-                };
-              }
-              ''
-                The tap configuration for the input device.
-              '';
+              in
+              defaultNullOpts.mkNullable xkbConfigSubmodule
+                {
+                  layout = "br";
+                  model = "pc104";
+                  options = {
+                    __type = "optional";
+                    value = "terminate:ctrl_alt_bksp";
+                  };
+                  repeat_delay = 600;
+                  repeat_rate = 25;
+                  rules = "";
+                  variant = "dvorak";
+                }
+                ''
+                  The keyboard configuration for the COSMIC compositor.
+                '';
+          };
         };
-      };
     in
-    lib.mkOption {
-      type = lib.types.submodule {
-        freeformType = with lib.types; attrsOf cosmicEntryValue;
-        options = {
-          active_hint = defaultNullOpts.mkBool true ''
-            Whether to show the active window hint.
-          '';
-
-          autotile = defaultNullOpts.mkBool false ''
-            Whether to automatically tile windows.
-          '';
-
-          autotile_behavior =
-            defaultNullOpts.mkRonEnum [ "Global" "PerWorkspace" ]
-              {
-                __type = "enum";
-                variant = "PerWorkspace";
-              }
-              ''
-                Automatic tiling behavior.
-
-                If set to Global, autotile applies to all windows in all workspaces.
-                If set to PerWorkspace, autotile only applies to new windows, and new workspaces.
-              '';
-
-          cursor_follows_focus = defaultNullOpts.mkBool false ''
-            Whether the cursor should follow the focused window.
-          '';
-
-          descale_xwayland = defaultNullOpts.mkBool false ''
-            Whether to let XWayland windows be scaled by themselves.
-          '';
-
-          focus_follows_cursor = defaultNullOpts.mkBool false ''
-            Whether the focused window should follow the cursor.
-          '';
-
-          focus_follows_cursor_delay = defaultNullOpts.mkUnsignedInt 250 ''
-            The delay in milliseconds before the focused window follows the cursor.
-          '';
-
-          input_default =
-            defaultNullOpts.mkNullable inputSubmodule
-              {
-                acceleration = {
-                  profile = {
-                    __type = "optional";
-                    value = {
-                      __type = "enum";
-                      variant = "Flat";
-                    };
-                  };
-                  speed = 0.0;
-                };
-                state = {
-                  __type = "enum";
-                  variant = "Enabled";
-                };
-              }
-              ''
-                The input configuration for mice.
-              '';
-
-          input_touchpad =
-            defaultNullOpts.mkNullable inputSubmodule
-              {
-                acceleration = {
-                  profile = {
-                    __type = "optional";
-                    value = {
-                      __type = "enum";
-                      variant = "Flat";
-                    };
-                  };
-                  speed = 0.0;
-                };
-                click_method = {
-                  __type = "optional";
-                  value = {
-                    __type = "enum";
-                    variant = "Clickfinger";
-                  };
-                };
-                disable_while_typing = {
-                  __type = "optional";
-                  value = true;
-                };
-                state = {
-                  __type = "enum";
-                  variant = "Enabled";
-                };
-                tap_config = {
-                  button_map = {
-                    __type = "optional";
-                    value = {
-                      __type = "enum";
-                      variant = "LeftMiddleRight";
-                    };
-                  };
-                  drag = {
-                    __type = "optional";
-                    value = true;
-                  };
-                  drag_lock = {
-                    __type = "optional";
-                    value = true;
-                  };
-                  enabled = {
-                    __type = "optional";
-                    value = true;
-                  };
-                };
-              }
-              ''
-                The input configuration for touchpad.
-              '';
-
-          workspaces =
-            let
-              workspacesSubmodule = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  workspace_layout = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (ronEnum [
-                        "Horizontal"
-                        "Vertical"
-                      ]);
-                    example = mkRonExpression 0 {
-                      __type = "enum";
-                      variant = "Vertical";
-                    } null;
-                    description = ''
-                      The layout of the workspaces.
-
-                      If set to Horizontal, workspaces are arranged horizontally.
-                      If set to Vertical, workspaces are arranged vertically.
-                    '';
-                  };
-
-                  workspace_mode = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (ronEnum [
-                        "Global"
-                        "OutputBound"
-                      ]);
-                    example = mkRonExpression 0 {
-                      __type = "enum";
-                      variant = "OutputBound";
-                    } null;
-                    description = ''
-                      The mode of the workspaces.
-
-                      If set to Global, workspaces are shared across all outputs.
-                      If set to OutputBound, workspaces are bound to the output they are created on.
-                    '';
-                  };
-                };
-              };
-            in
-            defaultNullOpts.mkNullable workspacesSubmodule
-              {
-                workspace_layout = {
-                  __type = "enum";
-                  variant = "Vertical";
-                };
-                workspace_mode = {
-                  __type = "enum";
-                  variant = "OutputBound";
-                };
-              }
-              ''
-                The workspaces configuration for the COSMIC compositor.
-              '';
-
-          xkb_config =
-            let
-              xkbConfigSubmodule = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  layout = lib.mkOption {
-                    type = with lib.types; maybeRonRaw str;
-                    example = "br";
-                    description = ''
-                      The keyboard layout.
-                    '';
-                  };
-
-                  model = lib.mkOption {
-                    type = with lib.types; maybeRonRaw str;
-                    example = "pc104";
-                    description = ''
-                      The keyboard model.
-                    '';
-                  };
-
-                  options = lib.mkOption {
-                    type = with lib.types; maybeRonRaw (ronOptionalOf (maybeRonRaw str));
-                    example = "terminate:ctrl_alt_bksp";
-                    description = ''
-                      The keyboard options.
-                    '';
-                  };
-
-                  repeat_delay = lib.mkOption {
-                    type = with lib.types; maybeRonRaw ints.u32;
-                    example = 600;
-                    description = ''
-                      The keyboard repeat delay.
-                    '';
-                  };
-
-                  repeat_rate = lib.mkOption {
-                    type = with lib.types; maybeRonRaw ints.u32;
-                    example = 25;
-                    description = ''
-                      The keyboard repeat rate.
-                    '';
-                  };
-
-                  rules = lib.mkOption {
-                    type = with lib.types; maybeRonRaw str;
-                    description = ''
-                      The keyboard rules.
-                    '';
-                  };
-
-                  variant = lib.mkOption {
-                    type = with lib.types; maybeRonRaw str;
-                    example = "dvorak";
-                    description = ''
-                      The keyboard variant.
-                    '';
-                  };
-                };
-              };
-            in
-            defaultNullOpts.mkNullable xkbConfigSubmodule
-              {
-                layout = "br";
-                model = "pc104";
-                options = {
-                  __type = "optional";
-                  value = "terminate:ctrl_alt_bksp";
-                };
-                repeat_delay = 600;
-                repeat_rate = 25;
-                rules = "";
-                variant = "dvorak";
-              }
-              ''
-                The keyboard configuration for the COSMIC compositor.
-              '';
-        };
-      };
-      default = { };
-      example = mkRonExpression 0 {
+    defaultNullOpts.mkNullable compositorSubmodule
+      {
         active_hint = true;
         autotile = false;
         autotile_behavior = {
@@ -613,17 +617,16 @@
           rules = "";
           variant = "dvorak";
         };
-      } null;
-      description = ''
+      }
+      ''
         The COSMIC compositor configuration.
       '';
-    };
 
   config.wayland.desktopManager.cosmic.configFile."com.system76.CosmicComp" =
     let
       cfg = config.wayland.desktopManager.cosmic;
     in
-    lib.mkIf (cfg.compositor != { }) {
+    lib.mkIf (cfg.compositor != null) {
       entries = cfg.compositor;
       version = 1;
     };

--- a/modules/idle.nix
+++ b/modules/idle.nix
@@ -2,10 +2,9 @@
 {
   options.wayland.desktopManager.cosmic.idle =
     let
-      inherit (lib.cosmic) defaultNullOpts mkRonExpression;
-    in
-    lib.mkOption {
-      type = lib.types.submodule {
+      inherit (lib.cosmic) defaultNullOpts;
+
+      inputSubmodule = lib.types.submodule {
         freeformType = with lib.types; attrsOf anything;
         options = {
           screen_off_time =
@@ -39,22 +38,22 @@
               '';
         };
       };
-      default = { };
-      example = mkRonExpression 0 {
+    in
+    defaultNullOpts.mkNullable inputSubmodule
+      {
         screen_off_time = 90000;
         suspend_on_ac_time = 180000;
         suspend_on_battery_time = 90000;
-      } null;
-      description = ''
+      }
+      ''
         Settings for the COSMIC idle manager.
       '';
-    };
 
   config.wayland.desktopManager.cosmic.configFile."com.system76.CosmicIdle" =
     let
       cfg = config.wayland.desktopManager.cosmic;
     in
-    lib.mkIf (cfg.idle != { }) {
+    lib.mkIf (cfg.idle != null) {
       entries = cfg.idle;
       version = 1;
     };

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -1,10 +1,9 @@
 { config, lib, ... }:
-let
-  inherit (lib.cosmic) defaultNullOpts mkRonExpression;
-in
 {
   options.wayland.desktopManager.cosmic.panels =
     let
+      inherit (lib.cosmic) defaultNullOpts;
+
       panelSubmodule = lib.types.submodule {
         freeformType = with lib.types; attrsOf cosmicEntryValue;
         options = {
@@ -177,78 +176,71 @@ in
         };
       };
     in
-    lib.mkOption {
-      type = lib.types.listOf panelSubmodule;
-      default = [ ];
-      example =
-        let
-          panels = [
-            {
-              anchor = {
-                __type = "enum";
-                variant = "Bottom";
-              };
-              anchor_gap = true;
-              autohide = {
-                __type = "optional";
-                value = {
-                  handle_size = 4;
-                  transition_time = 200;
-                  wait_time = 1000;
-                };
-              };
-              background = {
-                __type = "enum";
-                variant = "Dark";
-              };
-              expand_to_edges = true;
-              name = "Panel";
-              opacity = 1.0;
-              output = {
-                __type = "enum";
-                variant = "Name";
-                value = [ "Virtual-1" ];
-              };
-              plugins_center = {
-                __type = "optional";
-                value = [ "com.system76.CosmicAppletTime" ];
-              };
-              plugins_wings = {
-                __type = "optional";
-                value = {
-                  __type = "tuple";
-                  value = [
-                    [
-                      "com.system76.CosmicPanelWorkspacesButton"
-                      "com.system76.CosmicPanelAppButton"
-                      "com.system76.CosmicAppletWorkspaces"
-                    ]
-                    [
-                      "com.system76.CosmicAppletInputSources"
-                      "com.system76.CosmicAppletStatusArea"
-                      "com.system76.CosmicAppletTiling"
-                      "com.system76.CosmicAppletAudio"
-                      "com.system76.CosmicAppletNetwork"
-                      "com.system76.CosmicAppletBattery"
-                      "com.system76.CosmicAppletNotifications"
-                      "com.system76.CosmicAppletBluetooth"
-                      "com.system76.CosmicAppletPower"
-                    ]
-                  ];
-                };
-              };
-              size = {
-                __type = "enum";
-                variant = "M";
-              };
-            }
-          ];
-        in
-        mkRonExpression 0 panels null;
-      description = ''
+    defaultNullOpts.mkNullable (lib.types.listOf panelSubmodule)
+      [
+        {
+          anchor = {
+            __type = "enum";
+            variant = "Bottom";
+          };
+          anchor_gap = true;
+          autohide = {
+            __type = "optional";
+            value = {
+              handle_size = 4;
+              transition_time = 200;
+              wait_time = 1000;
+            };
+          };
+          background = {
+            __type = "enum";
+            variant = "Dark";
+          };
+          expand_to_edges = true;
+          name = "Panel";
+          opacity = 1.0;
+          output = {
+            __type = "enum";
+            variant = "Name";
+            value = [ "Virtual-1" ];
+          };
+          plugins_center = {
+            __type = "optional";
+            value = [ "com.system76.CosmicAppletTime" ];
+          };
+          plugins_wings = {
+            __type = "optional";
+            value = {
+              __type = "tuple";
+              value = [
+                [
+                  "com.system76.CosmicPanelWorkspacesButton"
+                  "com.system76.CosmicPanelAppButton"
+                  "com.system76.CosmicAppletWorkspaces"
+                ]
+                [
+                  "com.system76.CosmicAppletInputSources"
+                  "com.system76.CosmicAppletStatusArea"
+                  "com.system76.CosmicAppletTiling"
+                  "com.system76.CosmicAppletAudio"
+                  "com.system76.CosmicAppletNetwork"
+                  "com.system76.CosmicAppletBattery"
+                  "com.system76.CosmicAppletNotifications"
+                  "com.system76.CosmicAppletBluetooth"
+                  "com.system76.CosmicAppletPower"
+                ]
+              ];
+            };
+          };
+          size = {
+            __type = "enum";
+            variant = "M";
+          };
+        }
+      ]
+      ''
         The panels that will be displayed on the desktop.
       '';
-    };
 
   config =
     let
@@ -256,7 +248,7 @@ in
 
       version = 1;
     in
-    lib.mkIf (cfg.panels != [ ]) {
+    lib.mkIf (cfg.panels != null) {
       wayland.desktopManager.cosmic.configFile = lib.mkMerge (
         [
           {

--- a/modules/wallpapers.nix
+++ b/modules/wallpapers.nix
@@ -2,186 +2,188 @@
 {
   options.wayland.desktopManager.cosmic.wallpapers =
     let
-      inherit (lib.cosmic) mkRonExpression;
+      inherit (lib.cosmic) defaultNullOpts;
 
-      wallpapersSubmodule = lib.types.submodule {
-        freeformType = with lib.types; attrsOf cosmicEntryValue;
-        options = {
-          filter_by_theme = lib.mkOption {
-            type = with lib.types; maybeRonRaw bool;
-            example = true;
-            description = ''
-              Whether to filter the wallpapers by the active theme.
-            '';
-          };
+      wallpapersSubmodule =
+        let
+          inherit (lib.cosmic) mkRonExpression;
+        in
+        lib.types.submodule {
+          freeformType = with lib.types; attrsOf cosmicEntryValue;
+          options = {
+            filter_by_theme = lib.mkOption {
+              type = with lib.types; maybeRonRaw bool;
+              example = true;
+              description = ''
+                Whether to filter the wallpapers by the active theme.
+              '';
+            };
 
-          filter_method = lib.mkOption {
-            type =
-              with lib.types;
-              maybeRonRaw (ronEnum [
-                "Lanczos"
-                "Linear"
-                "Nearest"
-              ]);
-            example = mkRonExpression 0 {
-              __type = "enum";
-              variant = "Lanczos";
-            } null;
-          };
+            filter_method = lib.mkOption {
+              type =
+                with lib.types;
+                maybeRonRaw (ronEnum [
+                  "Lanczos"
+                  "Linear"
+                  "Nearest"
+                ]);
+              example = mkRonExpression 0 {
+                __type = "enum";
+                variant = "Lanczos";
+              } null;
+            };
 
-          output = lib.mkOption {
-            type = with lib.types; maybeRonRaw (either (enum [ "all" ]) str);
-            example = "all";
-            description = ''
-              The output(s) to show the wallpaper.
-            '';
-          };
+            output = lib.mkOption {
+              type = with lib.types; maybeRonRaw (either (enum [ "all" ]) str);
+              example = "all";
+              description = ''
+                The output(s) to show the wallpaper.
+              '';
+            };
 
-          rotation_frequency = lib.mkOption {
-            type = with lib.types; maybeRonRaw ints.unsigned;
-            example = 600;
-            description = ''
-              The frequency at which the wallpaper should change in seconds.
-            '';
-          };
+            rotation_frequency = lib.mkOption {
+              type = with lib.types; maybeRonRaw ints.unsigned;
+              example = 600;
+              description = ''
+                The frequency at which the wallpaper should change in seconds.
+              '';
+            };
 
-          sampling_method = lib.mkOption {
-            type =
-              with lib.types;
-              maybeRonRaw (ronEnum [
-                "Alphanumeric"
-                "Random"
-              ]);
-            example = mkRonExpression 0 {
-              __type = "enum";
-              variant = "Alphanumeric";
-            } null;
-            description = ''
-              The method to use for sampling the wallpapers.
-            '';
-          };
+            sampling_method = lib.mkOption {
+              type =
+                with lib.types;
+                maybeRonRaw (ronEnum [
+                  "Alphanumeric"
+                  "Random"
+                ]);
+              example = mkRonExpression 0 {
+                __type = "enum";
+                variant = "Alphanumeric";
+              } null;
+              description = ''
+                The method to use for sampling the wallpapers.
+              '';
+            };
 
-          scaling_mode = lib.mkOption {
-            type =
-              with lib.types;
-              maybeRonRaw (
-                either (ronEnum [
-                  "Stretch"
-                  "Zoom"
-                ]) (ronTupleEnumOf (ronTupleOf (maybeRonRaw (numbers.between 0.0 1.0)) 3) [ "Fit" ] 1)
-              );
-            example = mkRonExpression 0 {
-              __type = "enum";
-              variant = "Fit";
-              value = [
-                {
-                  __type = "tuple";
-                  value = [
-                    0.5
-                    1.0
-                    {
-                      __type = "raw";
-                      value = "0.345354352";
-                    }
-                  ];
-                }
-              ];
-            } null;
-          };
-
-          source =
-            let
-              gradientSubmodule = lib.types.submodule {
-                freeformType = with lib.types; attrsOf cosmicEntryValue;
-                options = {
-                  colors = lib.mkOption {
-                    type =
-                      with lib.types;
-                      maybeRonRaw (listOf (maybeRonRaw (ronTupleOf (maybeRonRaw (numbers.between 0.0 1.0)) 3)));
-                    example = mkRonExpression 0 [
-                      {
-                        __type = "tuple";
-                        value = [
-                          0.0
-                          0.0
-                          0.0
-                        ];
-                      }
-                      {
-                        __type = "tuple";
-                        value = [
-                          1.0
-                          1.0
-                          1.0
-                        ];
-                      }
-                    ] null;
-                  };
-
-                  radius = lib.mkOption {
-                    type = with lib.types; maybeRonRaw float;
-                    example = 0.0;
-                    description = ''
-                      The radius of the gradient.
-                    '';
-                  };
-                };
-              };
-            in
-            lib.mkOption {
+            scaling_mode = lib.mkOption {
               type =
                 with lib.types;
                 maybeRonRaw (
-                  either (ronTupleEnumOf (maybeRonRaw str) [ "Path" ] 1) (
-                    ronTupleEnumOf (either (ronTupleEnumOf gradientSubmodule [ "Gradient" ] 1) (
-                      ronTupleEnumOf (maybeRonRaw (ronTupleOf (maybeRonRaw float) 3)) [ "Single" ] 1
-                    )) [ "Color" ] 1
-                  )
+                  either (ronEnum [
+                    "Stretch"
+                    "Zoom"
+                  ]) (ronTupleEnumOf (ronTupleOf (maybeRonRaw (numbers.between 0.0 1.0)) 3) [ "Fit" ] 1)
                 );
               example = mkRonExpression 0 {
                 __type = "enum";
-                variant = "Color";
+                variant = "Fit";
                 value = [
                   {
-                    __type = "enum";
-                    variant = "Gradient";
+                    __type = "tuple";
                     value = [
+                      0.5
+                      1.0
                       {
-                        colors = [
-                          {
-                            __type = "tuple";
-                            value = [
-                              0.0
-                              0.0
-                              0.0
-                            ];
-                          }
-                          {
-                            __type = "tuple";
-                            value = [
-                              1.0
-                              1.0
-                              1.0
-                            ];
-                          }
-                        ];
-                        radius = 180.0;
+                        __type = "raw";
+                        value = "0.345354352";
                       }
                     ];
                   }
                 ];
               } null;
-              description = ''
-                The source of the wallpaper.
-              '';
             };
+
+            source =
+              let
+                gradientSubmodule = lib.types.submodule {
+                  freeformType = with lib.types; attrsOf cosmicEntryValue;
+                  options = {
+                    colors = lib.mkOption {
+                      type =
+                        with lib.types;
+                        maybeRonRaw (listOf (maybeRonRaw (ronTupleOf (maybeRonRaw (numbers.between 0.0 1.0)) 3)));
+                      example = mkRonExpression 0 [
+                        {
+                          __type = "tuple";
+                          value = [
+                            0.0
+                            0.0
+                            0.0
+                          ];
+                        }
+                        {
+                          __type = "tuple";
+                          value = [
+                            1.0
+                            1.0
+                            1.0
+                          ];
+                        }
+                      ] null;
+                    };
+
+                    radius = lib.mkOption {
+                      type = with lib.types; maybeRonRaw float;
+                      example = 0.0;
+                      description = ''
+                        The radius of the gradient.
+                      '';
+                    };
+                  };
+                };
+              in
+              lib.mkOption {
+                type =
+                  with lib.types;
+                  maybeRonRaw (
+                    either (ronTupleEnumOf (maybeRonRaw str) [ "Path" ] 1) (
+                      ronTupleEnumOf (either (ronTupleEnumOf gradientSubmodule [ "Gradient" ] 1) (
+                        ronTupleEnumOf (maybeRonRaw (ronTupleOf (maybeRonRaw float) 3)) [ "Single" ] 1
+                      )) [ "Color" ] 1
+                    )
+                  );
+                example = mkRonExpression 0 {
+                  __type = "enum";
+                  variant = "Color";
+                  value = [
+                    {
+                      __type = "enum";
+                      variant = "Gradient";
+                      value = [
+                        {
+                          colors = [
+                            {
+                              __type = "tuple";
+                              value = [
+                                0.0
+                                0.0
+                                0.0
+                              ];
+                            }
+                            {
+                              __type = "tuple";
+                              value = [
+                                1.0
+                                1.0
+                                1.0
+                              ];
+                            }
+                          ];
+                          radius = 180.0;
+                        }
+                      ];
+                    }
+                  ];
+                } null;
+                description = ''
+                  The source of the wallpaper.
+                '';
+              };
+          };
         };
-      };
     in
-    lib.mkOption {
-      type = lib.types.listOf wallpapersSubmodule;
-      default = [ ];
-      example = mkRonExpression 0 [
+    defaultNullOpts.mkNullable (lib.types.listOf wallpapersSubmodule)
+      [
         {
           output = "all";
           source = {
@@ -217,11 +219,10 @@
           };
           rotation_frequency = 600;
         }
-      ] null;
-      description = ''
+      ]
+      ''
         List of wallpapers to be used in COSMIC.
       '';
-    };
 
   config =
     let
@@ -235,7 +236,7 @@
 
       outputs = map (wallpaper: wallpaper.output) cfg.wallpapers;
     in
-    lib.mkIf (cfg.wallpapers != [ ]) {
+    lib.mkIf (cfg.wallpapers != null) {
       assertions = [
         {
           assertion = hasAllWallpaper -> builtins.length cfg.wallpapers == 1;


### PR DESCRIPTION
Make options default value be null, to avoid generating components with empty values in configurations.json. Also moves some let variables into the scope they are needed instead of globally.