### PR TITLE
fix: eval failure when cfg.panels is not set

### DIFF
--- a/modules/appearance.nix
+++ b/modules/appearance.nix
@@ -1371,7 +1371,8 @@
       home.activation.buildCosmicTheme =
         let
           needsBuild =
-            builtins.any (panel: panel.background != null && panel.background.variant == "Color") cfg.panels
+            cfg.panels != null
+            && builtins.any (panel: panel.background != null && panel.background.variant == "Color") cfg.panels
             || cfg.appearance.theme.dark != null
             || cfg.appearance.theme.light != null;
         in


### PR DESCRIPTION
Just importing the home manager module without any configuration, eval failed:
```console
┃        … while calling the 'any' builtin
┃          at /nix/store/g7kmwqfhwrgccb4z3vwdn46a5bvdzskg-source/modules/appearance.nix:1374:13:
┃          1373|           needsBuild =
┃          1374|             builtins.any (panel: panel.background != null && panel.background.variant == "Color") cfg.panels
┃              |             ^
┃          1375|             || cfg.appearance.theme.dark != null
┃ 
┃        … while evaluating the second argument passed to builtins.any
┃ 
┃        error: expected a list but found null: null
```