### PR TITLE
feat(wallpapers): improve output detection and warning messages

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -70,7 +70,7 @@ in
     scope: warnings:
     let
       prefix = messagePrefix scope;
-      process = warning: [ "${prefix} ${trim warning}" ];
+      process = warning: "${prefix} ${trim warning}";
     in
     map process warnings;
 }


### PR DESCRIPTION
- Add automatic detection of available display outputs
- Generate proper wallpaper state when using 'all' output mode
- Add helpful warnings when outputs aren't found or wallpapers are missing
- Improve error messages to be more descriptive for users

This implementation leverages the newly available importRON function to parse the COSMIC compositor's outputs.ron file, making it possible to automatically detect and configure wallpapers for all available displays when the 'all' output mode is used.