### PR TITLE
Local docs development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 **/*.rs.bk
 result*
 .direnv/
+docs/src/options/README.md
+docs/book

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,13 @@
               moduleRoot = ./modules;
             };
 
+            gen-local-options = pkgs.writeShellApplication {
+              name = "gen-local-options";
+              text = ''
+                root="$(git rev-parse --show-toplevel)"
+                cp ${self'.packages.home-manager-options} "$root/docs/src/options/README.md"
+              '';
+            };
             site =
               let
                 src =

--- a/shell.nix
+++ b/shell.nix
@@ -28,5 +28,6 @@ pkgs.mkShell {
       rustfmt
       statix-fix
       taplo
+      mdbook
     ];
 }


### PR DESCRIPTION
This PR tries to improve the docs development.

It adds the option to run mdbook in watch mode locally so you can see your changes live in the browser.
You have to run `nix run .#gen-local-options` once to generate the `options.md` file and place it 
in the right location.

Afterwards you can simply run `cd docs && mdbook watch --open` to see your changes live in the browser.