### PR TITLE
docs: fix getting-strated link

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -11,7 +11,7 @@ command-line interface with some utilities to use in conjunction with `cosmic-ma
 
 ## Getting started
 
-Ready to give it a try? Check out the [Getting started](./getting-started/README.md) guide to get started with `cosmic-manager`.
+Ready to give it a try? Check out the [Getting started](./getting-started/index.md) guide to get started with `cosmic-manager`.
 Once you're done, you can take a look at all of our available options in the [Options](./options/index.md) section.
 
 ## Found a bug?


### PR DESCRIPTION
Currently the link from the introduction page to the getting started page is broken.

This PR fixes the link.