### PR TITLE
Add support for COSMIC Monitor

### DIFF
--- a/modules/applications/by-name/cosmic-monitor/default.nix
+++ b/modules/applications/by-name/cosmic-monitor/default.nix
@@ -1,0 +1,30 @@
+{lib, ...}:
+lib.cosmic.applications.mkCosmicApplication {
+  name = "cosmic-monitor";
+  originalName = "COSMIC System Monitor";
+  identifier = "com.system76.CosmicMonitor";
+  configurationVersion = 1;
+
+  maintainers = [lib.maintainers.HeitorAugustoLN];
+
+  settingsOptions = let
+    inherit (lib.cosmic) defaultNullOpts;
+  in {
+    app_theme =
+      defaultNullOpts.mkRonEnum ["Dark" "Light" "System"]
+      {
+        __type = "enum";
+        variant = "System";
+      }
+      ''
+        The theme of the application.
+      '';
+  };
+
+  settingsExample = {
+    app_theme = {
+      __type = "enum";
+      variant = "System";
+    };
+  };
+}


### PR DESCRIPTION
This provides basic support for the new COSMIC Monitor app that was introduced in COSMIC Epoch 1.1. The only option so far is to adjust the app_theme.
