### PR TITLE
fix(panels): write autohide_behavior separately from autohide

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,15 +40,12 @@
         {
           checks = pkgs.callPackages ./tests { };
 
-          devShells.default = import ./shell.nix {
-            inherit pkgs;
-            inherit (self'.packages) cosmic-manager;
-          };
+          devShells.default = import ./shell.nix { inherit pkgs; };
 
           formatter = pkgs.treefmt;
 
           packages = {
-            default = self'.packages.cosmic-manager;
+            default = self'.packages.site;
 
             home-manager-options = mkOptionsDoc {
               inherit version;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -70,7 +70,7 @@ in
     scope: warnings:
     let
       prefix = messagePrefix scope;
-      process = warning: [ "${prefix} ${trim warning}" ];
+      process = warning: "${prefix} ${trim warning}";
     in
     map process warnings;
 }

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -26,55 +26,94 @@
             Whether there should be a gap between the panel and the screen edge.
           '';
 
-          # HACK: Submodule options won't show up if maybeRonRaw comes before it.
           autohide =
             defaultNullOpts.mkNullable
-              (lib.types.ronOptionalOf (
-                lib.types.submodule {
-                  freeformType = with lib.types; attrsOf anything;
-                  options = {
-                    handle_size = lib.mkOption {
-                      type =
-                        with lib.types;
-                        maybeRonRaw (
-                          addCheck ints.u32 (x: x > 0)
-                          // {
-                            description = "Non-zero 32-bit unsigned integer";
-                          }
-                        );
-                      example = 4;
-                      description = ''
-                        The size of the handle in pixels.
-                      '';
-                    };
-                    transition_time = lib.mkOption {
-                      type = with lib.types; maybeRonRaw ints.u32;
-                      example = 200;
-                      description = ''
-                        The time in milliseconds it should take to transition the panel hiding.
-                      '';
-                    };
-                    wait_time = lib.mkOption {
-                      type = with lib.types; maybeRonRaw ints.u32;
-                      example = 1000;
-                      description = ''
-                        The time in milliseconds without pointer focus before the panel hides.
-                      '';
-                    };
-                  };
-                }
-              ))
+              (
+                with lib.types;
+                either
+                  (ronEnum [
+                    "Always"
+                    "Never"
+                    "OnOverlap"
+                  ])
+                  # Legacy pre-epoch-1.5 form, kept for backwards compatibility.
+                  (ronOptionalOf (attrsOf anything))
+              )
               {
-                __type = "optional";
-                value = {
-                  handle_size = 4;
-                  transition_time = 200;
-                  wait_time = 1000;
-                };
+                __type = "enum";
+                variant = "OnOverlap";
               }
               ''
-                Whether the panel should autohide and the settings for autohide.
-                If set the `value` is set to `null`, the panel will not autohide.
+                When the panel should hide itself.
+
+                - `Never`: the panel is always visible.
+                - `OnOverlap`: the panel hides when a window overlaps it (intellihide).
+                - `Always`: the panel is always hidden.
+
+                The timings used while hiding and unhiding are configured separately,
+                in `autohide_behavior`.
+
+                COSMIC before epoch 1.5 stored the mode and the timings together in this
+                key, as a RON optional wrapping the timing attributes. That form is still
+                accepted here and is migrated automatically, but it is deprecated: COSMIC
+                no longer reads timings from this key, so set the enum and put the timings
+                in `autohide_behavior` instead.
+              '';
+
+          # HACK: Submodule options won't show up if maybeRonRaw comes before it.
+          autohide_behavior =
+            defaultNullOpts.mkNullable
+              (lib.types.submodule {
+                freeformType = with lib.types; attrsOf anything;
+                options = {
+                  handle_size = lib.mkOption {
+                    type =
+                      with lib.types;
+                      maybeRonRaw (
+                        addCheck ints.u32 (x: x > 0)
+                        // {
+                          description = "Non-zero 32-bit unsigned integer";
+                        }
+                      );
+                    example = 4;
+                    description = ''
+                      The size of the handle in pixels.
+                    '';
+                  };
+                  transition_time = lib.mkOption {
+                    type = with lib.types; maybeRonRaw ints.u32;
+                    example = 200;
+                    description = ''
+                      The time in milliseconds it should take to transition the panel hiding.
+                    '';
+                  };
+                  unhide_delay = lib.mkOption {
+                    type = with lib.types; maybeRonRaw ints.u32;
+                    example = 200;
+                    description = ''
+                      The time in milliseconds before the panel unhides.
+                    '';
+                  };
+                  wait_time = lib.mkOption {
+                    type = with lib.types; maybeRonRaw ints.u32;
+                    example = 1000;
+                    description = ''
+                      The time in milliseconds without pointer focus before the panel hides.
+                    '';
+                  };
+                };
+              })
+              {
+                handle_size = 4;
+                transition_time = 200;
+                unhide_delay = 200;
+                wait_time = 1000;
+              }
+              ''
+                The timings the panel uses when hiding and unhiding.
+
+                Only takes effect when `autohide` is not `Never`. COSMIC rejects this
+                struct unless all four attributes are present, so set them together.
               '';
 
           background =
@@ -199,12 +238,14 @@
           };
           anchor_gap = true;
           autohide = {
-            __type = "optional";
-            value = {
-              handle_size = 4;
-              transition_time = 200;
-              wait_time = 1000;
-            };
+            __type = "enum";
+            variant = "OnOverlap";
+          };
+          autohide_behavior = {
+            handle_size = 4;
+            transition_time = 200;
+            unhide_delay = 200;
+            wait_time = 1000;
           };
           background = {
             __type = "enum";
@@ -262,13 +303,56 @@
       cfg = config.wayland.desktopManager.cosmic;
 
       version = 1;
+
+      # COSMIC before epoch 1.5 stored the autohide mode and its timings in a single
+      # `autohide` key, as `Option<AutoHideBehavior>`. Since epoch 1.5 `autohide` is an
+      # enum and the timings live in `autohide_behavior`. The panel still parses the old
+      # shape, but throws the timings away, so a config written in the old form silently
+      # loses them. Rewrite it here instead.
+      isLegacyAutohide = autohide: autohide != null && (autohide.__type or null) == "optional";
+
+      legacyPanels = lib.filter (panel: isLegacyAutohide panel.autohide) cfg.panels;
+
+      migrateAutohide =
+        panel:
+        if !(isLegacyAutohide panel.autohide) then
+          panel
+        else
+          let
+            behavior = panel.autohide.value;
+          in
+          panel
+          // {
+            autohide = {
+              __type = "enum";
+              variant = if behavior == null then "Never" else "OnOverlap";
+            };
+
+            autohide_behavior =
+              if panel.autohide_behavior != null || behavior == null then
+                panel.autohide_behavior
+              else
+                # unhide_delay has no legacy counterpart; use the COSMIC default.
+                { unhide_delay = 200; } // behavior;
+          };
+
+      panels = map migrateAutohide cfg.panels;
     in
     lib.mkIf (cfg.panels != null) {
+      warnings = lib.cosmic.mkWarnings "panels" (
+        map (panel: ''
+          Panel `${panel.name}` sets `autohide` to a RON optional, which COSMIC has not
+          read timings from since epoch 1.5. It has been migrated automatically, but you
+          should set `autohide` to an enum (`Always`, `Never` or `OnOverlap`) and move the
+          timings to `autohide_behavior`.
+        '') legacyPanels
+      );
+
       wayland.desktopManager.cosmic.configFile = lib.mkMerge (
         [
           {
             "com.system76.CosmicPanel" = {
-              entries.entries = map (panel: panel.name) cfg.panels;
+              entries.entries = map (panel: panel.name) panels;
               inherit version;
             };
           }
@@ -278,7 +362,7 @@
             entries = panel;
             inherit version;
           };
-        }) cfg.panels)
+        }) panels)
       );
 
       home.activation.restartCosmicPanel = lib.mkIf (cfg.panels != null) (

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -9,6 +9,16 @@
     let
       inherit (lib.cosmic) defaultNullOpts;
 
+      panelSize =
+        with lib.types;
+        either (ronEnum [
+          "XS"
+          "S"
+          "M"
+          "L"
+          "XL"
+        ]) (ronTupleEnumOf ints.u32 [ "Custom" ] 1);
+
       panelSubmodule = lib.types.submodule {
         freeformType = with lib.types; attrsOf anything;
         options = {
@@ -116,6 +126,17 @@
                 struct unless all four attributes are present, so set them together.
               '';
 
+          autohover_delay_ms =
+            defaultNullOpts.mkRonOptionalOf lib.types.ints.u32
+              {
+                __type = "optional";
+                value = 500;
+              }
+              ''
+                The time in milliseconds a pointer must hover an applet before its popup
+                opens. Set the `value` to `null` to disable hover-to-open entirely.
+              '';
+
           background =
             defaultNullOpts.mkNullableWithRaw
               (
@@ -134,9 +155,53 @@
                 The appearance of the panel.
               '';
 
+          border_radius = defaultNullOpts.mkU32 8 ''
+            The radius of the panel's corners, in pixels.
+          '';
+
+          exclusive_zone = defaultNullOpts.mkBool true ''
+            Whether the panel reserves an exclusive zone, so that maximised windows are
+            laid out beside it rather than underneath it.
+
+            COSMIC ignores this while `autohide` is not `Never`, since a hidden panel
+            cannot hold a zone open.
+          '';
+
           expand_to_edges = defaultNullOpts.mkBool true ''
             Whether the panel should expand to the edges of the screen.
           '';
+
+          keep_style_on_maximize = defaultNullOpts.mkBool false ''
+            Whether the panel keeps its configured styling when a window is maximised.
+
+            When `false`, COSMIC drops the panel's background and rounding while a
+            maximised window is focused.
+          '';
+
+          keyboard_interactivity =
+            defaultNullOpts.mkRonEnum [ "Exclusive" "None" "OnDemand" ]
+              {
+                __type = "enum";
+                variant = "OnDemand";
+              }
+              ''
+                How the panel's layer surface takes keyboard focus.
+
+                - `None`: the panel never receives keyboard input.
+                - `OnDemand`: the panel receives keyboard input when it is clicked.
+                - `Exclusive`: the panel takes keyboard focus away from other surfaces.
+              '';
+
+          layer =
+            defaultNullOpts.mkRonEnum [ "Background" "Bottom" "Overlay" "Top" ]
+              {
+                __type = "enum";
+                variant = "Top";
+              }
+              ''
+                The `wlr-layer-shell` layer the panel is placed on, which decides what it
+                is drawn above and below.
+              '';
 
           name = lib.mkOption {
             type = lib.types.str;
@@ -176,6 +241,15 @@
               ''
                 The output(s) the panel should be displayed on.
               '';
+
+          padding = defaultNullOpts.mkU32 4 ''
+            The padding around the panel's contents, in pixels.
+          '';
+
+          padding_overlap = defaultNullOpts.mkNullableWithRaw (lib.types.numbers.between 0.0 1.0) 0.5 ''
+            How much of the panel's padding neighbouring applets are allowed to overlap,
+            as a ratio between `0.0` and `1.0`.
+          '';
 
           plugins_center =
             defaultNullOpts.mkRonOptionalOf (with lib.types; listOf str)
@@ -218,14 +292,61 @@
               '';
 
           size =
-            defaultNullOpts.mkRonEnum [ "XS" "S" "M" "L" "XL" ]
+            defaultNullOpts.mkNullableWithRaw panelSize
               {
                 __type = "enum";
                 variant = "M";
               }
               ''
-                The size of the panel.
+                The size of the panel, either one of the named sizes or
+                `Custom(<pixels>)`.
               '';
+
+          size_center =
+            defaultNullOpts.mkRonOptionalOf panelSize
+              {
+                __type = "optional";
+                value = {
+                  __type = "enum";
+                  variant = "M";
+                };
+              }
+              ''
+                Size override for the applets in the center of the panel. Set the `value`
+                to `null` to use `size`.
+              '';
+
+          size_wings =
+            defaultNullOpts.mkRonOptionalOf
+              (with lib.types; ronTupleOf (ronOptionalOf (maybeRonRaw panelSize)) 2)
+              {
+                __type = "optional";
+                value = {
+                  __type = "tuple";
+                  value = [
+                    {
+                      __type = "optional";
+                      value = {
+                        __type = "enum";
+                        variant = "S";
+                      };
+                    }
+                    {
+                      __type = "optional";
+                      value = null;
+                    }
+                  ];
+                };
+              }
+              ''
+                Size overrides for the applets on the left/top and right/bottom sides of
+                the panel, respectively. Each side is itself optional: set a side to
+                `null` to use `size` for it.
+              '';
+
+          spacing = defaultNullOpts.mkU32 0 ''
+            The space between the panel's applets, in pixels.
+          '';
         };
       };
     in


### PR DESCRIPTION
## Panel autohide has been silently dropping its timings since COSMIC epoch 1.5

COSMIC epoch 1.5 (cosmic-panel 1.5.0) split panel autohide configuration into two keys:

```rust
pub autohide: AutoHide,                   // enum Never | OnOverlap | Always
pub autohide_behavior: AutoHideBehavior,  // wait_time, transition_time, handle_size, unhide_delay
```

`modules/panels.nix` only ever wrote the pre-1.5 shape — a RON optional wrapping the timing attributes, in `autohide`. cosmic-panel still accepts that shape, but its hand-written `Deserialize` impl for `AutoHide` maps it to `Never`/`OnOverlap` and throws the timings away:

```rust
Either::Legacy(Some(_)) => {
    NEEDS_MIGRATION.store(true, Ordering::Relaxed);
    Self::OnOverlap
},
```

So every `wait_time`, `transition_time` and `handle_size` set through cosmic-manager was written to disk, parsed, and discarded. No error, no warning — the panel just keeps its defaults. I hit this trying to change my dock's autohide delay and spent a while assuming my rebuild hadn't applied.

### `fix(panels): write autohide_behavior separately from autohide`

`autohide` is now a `Never` / `OnOverlap` / `Always` enum, and the timings move to a new `autohide_behavior` option (including `unhide_delay`, which has no pre-1.5 counterpart).

Existing configurations are not broken. Panels still using the old shape are migrated during evaluation — `Some((..))` becomes `OnOverlap` plus its timings, `None` becomes `Never` — and emit a deprecation warning naming the panel. `unhide_delay` is filled in with COSMIC's default of 200. An explicitly set `autohide_behavior` always wins over the migrated value.

This also fixes `lib.cosmic.mkWarnings`, which wrapped each message in a list and so produced `[[str]]` where `warnings` expects `[str]`. It had no callers until now.

### `fix(flake): drop references to the removed cosmic-manager package`

`packages.default` and `devShells.default` still pointed at `self'.packages.cosmic-manager`, which went away with the CLI in 0524f83 / 819d4d2. Any evaluation of `packages` failed with `attribute 'cosmic-manager' missing`, so `nix flake check` could not run at all on `main`. `packages.default` now builds the docs site, and `shell.nix` is imported without the argument it already ignored.

Happy to split this one out if you'd rather take it separately — it's unrelated to the panel work, but the branch can't be checked without it.

### `feat(panels): add options for the remaining panel settings`

`CosmicPanelConfig` has eleven fields the module never declared, so they were reachable only through the submodule's freeform type: no type checking, no defaults, no documentation. This declares `autohover_delay_ms`, `border_radius`, `exclusive_zone`, `keep_style_on_maximize`, `keyboard_interactivity`, `layer`, `padding`, `padding_overlap`, `size_center`, `size_wings` and `spacing`.

`size_center` and `size_wings` are both `PanelSize`-valued, so the size type is now shared between them and `size`. That also picks up `PanelSize::Custom`, which `size` previously could not express.

Drop this commit if you'd prefer the fix on its own.

## Testing

`nix flake check` passes (it could not run on `main` before the flake fix), and `nix build .#home-manager-options` succeeds, which forces every option declaration.

Beyond that I built a real home-manager closure against the branch and read back the generated `configurations.json`:

| `autohide` input | written `autohide` | written `autohide_behavior` |
|---|---|---|
| `mkRON "enum" "OnOverlap"` | `OnOverlap` | `(handle_size: 4, transition_time: 100, unhide_delay: 100, wait_time: 500)` |
| legacy `mkRON "optional" { .. }` | `OnOverlap` | timings preserved, `unhide_delay: 200` |
| legacy `mkRON "optional" null` | `Never` | absent |

The legacy rows emitted the deprecation warning. Output matches the RON that cosmic-panel itself writes to `~/.config/cosmic/com.system76.CosmicPanel.<name>/v1/` on epoch 1.5, and my panels pick up the timings live.

For the new options, a configuration that previously set them through the freeform type produces a byte-identical closure once they are typed. The new type constructions serialize as expected:

```
size        = Custom(24)
size_center = Some(L)
size_wings  = Some((Some(S), None))
autohover_delay_ms = Some(250)
```
